### PR TITLE
feat(updates): refactor

### DIFF
--- a/api/db/init.ts
+++ b/api/db/init.ts
@@ -7,7 +7,9 @@ export async function initTables() {
 			name VARCHAR(255),
 			icon VARCHAR(255),
 			members INT,
-			cooldown INT DEFAULT 30000
+			cooldown INT DEFAULT 30000,
+			updates_enabled BOOLEAN DEFAULT FALSE,
+			updates_channel_id VARCHAR(255) DEFAULT NULL
 		)
 	`;
   const createUsersTable = `
@@ -34,14 +36,6 @@ export async function initTables() {
 		)
 	`;
   // FOREIGN KEY (guild_id) REFERENCES guilds(id)
-  const createUpdatesTable = `
-		CREATE TABLE IF NOT EXISTS updates (
-			guild_id VARCHAR(255) NOT NULL PRIMARY KEY,
-			channel_id VARCHAR(255) NOT NULL,
-			enabled BOOLEAN DEFAULT FALSE
-		)
-	`;
-  // FOREIGN KEY (guild_id) REFERENCES guilds(id)
 
   pool.query(createGuildsTable, (err) => {
     if (err) {
@@ -64,14 +58,6 @@ export async function initTables() {
       console.error("Error creating roles table:", err);
     } else {
       console.log("Roles table created");
-    }
-  });
-
-  pool.query(createUpdatesTable, (err) => {
-    if (err) {
-      console.error("Error creating updates table:", err);
-    } else {
-      console.log("Updates table created");
     }
   });
 }

--- a/api/db/queries/guilds.ts
+++ b/api/db/queries/guilds.ts
@@ -7,7 +7,10 @@ export interface Guild {
 	icon: string;
 	members: number;
 	cooldown: number;
+	updates_enabled: 0 | 1;
+	updates_channel_id: string | null;
 }
+
 
 export async function getGuild(guildId: string): Promise<[QueryError, null] | [null, Guild | null]> {
 	return new Promise((resolve, reject) => {
@@ -21,24 +24,22 @@ export async function getGuild(guildId: string): Promise<[QueryError, null] | [n
 	});
 }
 
-export async function updateGuild(guild: Guild): Promise<[QueryError | null, null] | [null, Guild[]]> {
+export async function updateGuild(guild: Omit<Guild, "cooldown" | "updates_enabled" | "updates_channel_id">): Promise<[QueryError | null, null] | [null, Guild[]]> {
 	return new Promise((resolve, reject) => {
 		pool.query(
 			`
-			INSERT INTO guilds (id, name, icon, members, cooldown)
+			INSERT INTO guilds (id, name, icon, members)
 			VALUES (?, ?, ?, ?, ?, ?)
 			ON DUPLICATE KEY UPDATE
 				name = VALUES(name),
 				icon = VALUES(icon),
-				members = VALUES(members),
-				cooldown = VALUES(cooldown)
+				members = VALUES(members)
 			`,
 			[
 				guild.id,
 				guild.name,
 				guild.icon,
 				guild.members,
-				guild.cooldown
 			],
 			(err, results) => {
 				console.dir(results, { depth: null });

--- a/bot/events/messageCreate.ts
+++ b/bot/events/messageCreate.ts
@@ -9,7 +9,7 @@ client.on('messageCreate', async (message: Message) => {
 	if (message.author.bot) return;
 
 	const cooldownTime = (await getCooldown(message.guildId as string))?.cooldown ?? 30_000;
-	
+
 	const cooldown = cooldowns.get(message.author.id);
 	if (cooldown && Date.now() - cooldown < cooldownTime) return;
 
@@ -17,7 +17,7 @@ client.on('messageCreate', async (message: Message) => {
 	const pfp: string = message.member?.displayAvatarURL() ?? message.author.displayAvatarURL()
 	const name: string = message.author.username;
 	const nickname: string = message.member?.nickname ?? message.author.globalName ?? message.author.username;
-	await makePOSTRequest(message.guildId as string, message.author.id, xpToGive, pfp, name, nickname);
+	await makePOSTRequest(message.guildId as string, message.author.id, message.channel.id, xpToGive, pfp, name, nickname);
 	cooldowns.set(message.author.id, Date.now());
 
 	const guildName = message.guild?.name;

--- a/bot/utils/handleLevelChange.ts
+++ b/bot/utils/handleLevelChange.ts
@@ -1,30 +1,14 @@
 // import quickEmbed from "./quickEmbed";
 import type { TextChannel } from "discord.js";
 import client from "..";
+import { getUpdatesChannel } from "./requestAPI";
 
-export default async function(guild: string, user: string, level: number) {
-	const hasUpdates = await checkIfGuildHasUpdatesEnabled(guild);
+export default async function(guild: string, user: string, channelId: string, level: number) {
+	const hasUpdates = await getUpdatesChannel(guild);
 	if (!hasUpdates.enabled) return;
 
-	const channel = await client.channels.fetch(hasUpdates.channelId) as TextChannel;
+	const channel = await client.channels.fetch(hasUpdates.channelId ?? channelId) as TextChannel;
 	if (channel) {
 		channel.send(`<@${user}> has reached level ${level}!`);
 	}
-}
-
-export async function checkIfGuildHasUpdatesEnabled(guild: string): Promise<{ enabled: boolean, channelId: string }> {
-	const response = await fetch(`http://localhost:18103/admin/updates/${guild}/get`, {
-		headers: {
-			'Content-Type': 'application/json',
-		},
-		body: JSON.stringify({ auth: process.env.AUTH }),
-		method: 'POST',
-	});
-
-	const data = await response.json();
-
-	return {
-		enabled: data[0].enabled === 1,
-		channelId: data[0].channel_id,
-	};
 }

--- a/bot/utils/requestAPI.ts
+++ b/bot/utils/requestAPI.ts
@@ -1,6 +1,6 @@
 import handleLevelChange from "./handleLevelChange";
 
-export async function makePOSTRequest(guild: string, user: string, xp: number, pfp: string, name: string, nickname: string) {
+export async function makePOSTRequest(guild: string, user: string, channel: string, xp: number, pfp: string, name: string, nickname: string) {
 	await fetch(`http://localhost:18103/post/${guild}/${user}`, {
 		headers: {
 			'Content-Type': 'application/json',
@@ -11,7 +11,7 @@ export async function makePOSTRequest(guild: string, user: string, xp: number, p
 	}).then(res => {
 		return res.json()
 	}).then(data => {
-		if (data.sendUpdateEvent) handleLevelChange(guild, user, data.level)
+		if (data.sendUpdateEvent) handleLevelChange(guild, user, channel, data.level)
 	})
 }
 
@@ -110,7 +110,7 @@ export async function addRole(guild: string, role: string, level: number): Promi
 //#endregion
 
 //#region Updates
-export async function checkIfGuildHasUpdatesEnabled(guild: string) {
+export async function getUpdatesChannel(guild: string) {
 	const response = await fetch(`http://localhost:18103/admin/updates/${guild}/get`, {
 		"headers": {
 			'Content-Type': 'application/json',
@@ -121,13 +121,24 @@ export async function checkIfGuildHasUpdatesEnabled(guild: string) {
 	});
 	return response.status === 200 ? response.json() : {};
 }
-export async function enableUpdates(guild: string, channelId: string) {
-	const response = await fetch(`http://localhost:18103/admin/updates/${guild}/enable`, {
+export async function setUpdatesChannel(guild: string, channelId: string | null) {
+	const response = await fetch(`http://localhost:18103/admin/updates/${guild}/set`, {
 		"headers": {
 			'Content-Type': 'application/json',
 			'Authorization': process.env.AUTH as string,
 		},
 		"body": JSON.stringify({ extraData: { channelId } }),
+		"method": "POST"
+	});
+	return response.status === 200;
+}
+export async function enableUpdates(guild: string) {
+	const response = await fetch(`http://localhost:18103/admin/updates/${guild}/enable`, {
+		"headers": {
+			'Content-Type': 'application/json',
+			'Authorization': process.env.AUTH as string,
+		},
+		"body": JSON.stringify({}),
 		"method": "POST"
 	});
 	return response.status === 200;


### PR DESCRIPTION
- remove `updates` table
- add `updates_enabled` and `updates_channel_id` to `guilds` table
- default is now set to send messages in the current channel
- update messages now work properly
- (extra) fix xp progress bar being wrong in rankcard